### PR TITLE
マルチOS対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 ## 概要・使用方法:
 
 USBにつないだ機器のMACアドレスを取得する.  
-第一引数にUSBデバイスが使用するCOMポートの番号を与える.  
+第一引数にUSBデバイスが使用するポート名を与える.（WindowsはCOM?、Linuxは/dev/ttyUSB0やttyACM0）  
 MACアドレスは以下の2つのフォーマット形式で出力される.
 
 ``` sh
-$ python getMacAddrFromCOM.py 8
+$ python getMacAddrFromCOM.py COM8
 FF:FF:FF:FF:FF:FF
 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 ```
 
 ## 使用要件:
 
-機器を接続しているCOMポートの番号は、別途デバイスマネージャーなどで調べておくこと.
+機器を接続しているCOMポート名は、別途デバイスマネージャーなどで調べておくこと.
 
 esptoolを使用するため事前にインストールしておくこと.
 
@@ -37,11 +37,11 @@ $ PATH=$HOME/.local/bin:$PATH
 ## Overview & Usage:
 
 This script retrieves the MAC address of a device connected via USB.  
-Pass the COM port number used by the USB device as the first argument.  
+Pass the port name used by the USB device as the first argument.  (ex. Windows: COM8, Linux: /dev/ttyUSB0 or ttyACM0)
 The MAC address will be output in the following two formats:
 
 ```sh
-$ python getMacAddr.py 8
+$ python getMacAddr.py COM8
 FF:FF:FF:FF:FF:FF
 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 ```

--- a/getMacAddrFromCOM.py
+++ b/getMacAddrFromCOM.py
@@ -13,20 +13,22 @@
 # $ PATH=$HOME/.local/bin:$PATH
 # 
 # 使用方法:
-# 第一引数にCOMポートの番号を与える
-# $ python getMacAddr.py 8
+# 第一引数にポート名を与える(Windows: COM8, Linux: /dev/ttyUSB0orACM0)
+# $ python getMacAddr.py COM8
 # FF:FF:FF:FF:FF:FF
 # 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 
 import subprocess
 import sys
 import re
+import shutil
 
 def get_mac_address(com_port):
     try:
         # esptool コマンドを実行
+        esptool_path = shutil.which("esptool.py")
         result = subprocess.run([
-            "esptool", "--port", f"COM{com_port}", "read_mac"
+            esptool_path, "--port", com_port, "read_mac"
         ], capture_output=True, text=True, check=True)
         
         # 標準出力からMACアドレスを抽出
@@ -46,7 +48,7 @@ def get_mac_address(com_port):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("使用方法: python getMacAddr.py <COMポート番号>")
+        print("使用方法: python getMacAddr.py <ポート名>")
         sys.exit(1)
     
     com_port = sys.argv[1]


### PR DESCRIPTION
subprocessのコマンド指定が"esptool"(exe)でしたので、esptool.pyにして他のOSでも動くように変更しました。（検証したのはUbuntu22.04のみです。)

